### PR TITLE
Change QT App Name 

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -48,9 +48,9 @@ static const int MAX_URI_LENGTH = 255;
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 36
 
-#define QAPP_ORG_NAME "Bitcoin"
-#define QAPP_ORG_DOMAIN "bitcoin.org"
-#define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
-#define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+#define QAPP_ORG_NAME "Bitcoin-Atom"
+#define QAPP_ORG_DOMAIN "bitcoinatom.io"
+#define QAPP_APP_NAME_DEFAULT "Bitcoin-Atom-Qt"
+#define QAPP_APP_NAME_TESTNET "Bitcoin-Atom-Qt-testnet"
 
 #endif // BITCOIN_QT_GUICONSTANTS_H


### PR DESCRIPTION
If you use the regular Bitcoin app name, it will mess up the previous Bitcoin and/or Bitcoin forks you may have installed, use the settings from that registry location, and overwrite your wallet.dat and other settins.

Thus making irreversible damage to other wallets