### PR TITLE
Fix txindex=0 on new node with no previous block/chainstate data

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1462,7 +1462,7 @@ bool AppInitMain()
                     return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
 
                 // Check for changed -txindex state
-                if (fTxIndex != DEFAULT_TXINDEX) {
+                if (fTxIndex != gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
                     strLoadError = _("You need to rebuild the database using -reindex to change -txindex");
                     break;
                 }


### PR DESCRIPTION
When starting an empty node with : 
prune=1000
txindex=0

It would fail to validate the txindex value hence would not be able to start with a pruning node from scratch, this fixes it